### PR TITLE
Fix line continuation to PubMed TI field

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,5 +211,5 @@ This crate is under active. There may be some breaking changes.
 ## Support
 
 - Documentation: [docs.rs](https://docs.rs/biblib)
-- Issues: [GitHub Issues](https://github.com/aliazlanpro/biblib/issues)
-- Discussions: [GitHub Discussions](https://github.com/aliazlanpro/biblib/discussions)
+- Issues: [GitHub Issues](https://github.com/AliAzlanDev/biblib/issues)
+- Discussions: [GitHub Discussions](https://github.com/AliAzlanDev/biblib/discussions)

--- a/src/pubmed.rs
+++ b/src/pubmed.rs
@@ -91,10 +91,11 @@ impl PubMedParser {
         match field {
             "FAU" => citation.authors.push(Self::parse_author(content)),
             "AB" => {
-                citation
-                    .abstract_text
-                    .get_or_insert_with(String::new)
-                    .push_str(content);
+                let abstract_text = citation.abstract_text.get_or_insert_with(String::new);
+                if !abstract_text.is_empty() && !abstract_text.ends_with(char::is_whitespace) && !abstract_text.ends_with('-') {
+                    abstract_text.push(' ');
+                }
+                abstract_text.push_str(content);
             }
             "AD" => {
                 if let Some(last_author) = citation.authors.last_mut() {
@@ -107,7 +108,7 @@ impl PubMedParser {
                 }
             }
             "TI" => {
-                if !citation.title.is_empty() && !citation.title.ends_with(' ') {
+                if !citation.title.is_empty() && !citation.title.ends_with(char::is_whitespace) && !citation.title.ends_with('-') {
                     citation.title.push(' ')
                 }
                 citation.title.push_str(content)
@@ -414,11 +415,13 @@ AU  - Zhang H
     }
 
     #[test]
-    fn test_title_continued_line() {
+    fn test_continued_line() {
         let input = r#"PMID- 31181385
 DP  - 2019 Dec
 TI  - Fantastic yeasts and where to find them: the hidden diversity of dimorphic fungal 
       pathogens.
+AB  - This is a long abstract that spans
+      multiple lines for testing purposes.
 FAU - Van Dyke, Marley C Caballero
 AU  - Van Dyke MCC
 "#;
@@ -428,6 +431,23 @@ AU  - Van Dyke MCC
         let citation = &result[0];
         assert_eq!(citation.pmid.as_deref(), Some("31181385"));
         assert_eq!(citation.title, "Fantastic yeasts and where to find them: the hidden diversity of dimorphic fungal pathogens.");
+        assert_eq!(result[0].abstract_text.as_deref(), Some("This is a long abstract that spans multiple lines for testing purposes."));
         assert_eq!(citation.authors.len(), 1);
+    }
+
+    #[test]
+    fn test_hyphenated_continuation() {
+        let input = r#"PMID- 12345678
+TI  - Self-
+      assembled structures
+AB  - Self-
+      assembled structures are important.
+FAU - Smith, John
+
+"#;
+        let parser = PubMedParser::new();
+        let result = parser.parse(input).unwrap();
+        assert_eq!(result[0].title, "Self-assembled structures");
+        assert_eq!(result[0].abstract_text.as_deref(), Some("Self-assembled structures are important."));
     }
 }

--- a/src/pubmed.rs
+++ b/src/pubmed.rs
@@ -106,6 +106,12 @@ impl PubMedParser {
                     }
                 }
             }
+            "TI" => {
+                if !citation.title.is_empty() && !citation.title.ends_with(' ') {
+                    citation.title.push(' ')
+                }
+                citation.title.push_str(content)
+            }
             _ => {
                 if let Some(values) = citation.extra_fields.get_mut(field) {
                     if let Some(last_value) = values.last_mut() {
@@ -405,5 +411,23 @@ AU  - Zhang H
         ));
 
         assert!(PubMedParser::validate_line("Invalid- line", 1).is_err());
+    }
+
+    #[test]
+    fn test_title_continued_line() {
+        let input = r#"PMID- 31181385
+DP  - 2019 Dec
+TI  - Fantastic yeasts and where to find them: the hidden diversity of dimorphic fungal 
+      pathogens.
+FAU - Van Dyke, Marley C Caballero
+AU  - Van Dyke MCC
+"#;
+        let parser = PubMedParser::new();
+        let result = parser.parse(input).unwrap();
+        assert_eq!(result.len(), 1);
+        let citation = &result[0];
+        assert_eq!(citation.pmid.as_deref(), Some("31181385"));
+        assert_eq!(citation.title, "Fantastic yeasts and where to find them: the hidden diversity of dimorphic fungal pathogens.");
+        assert_eq!(citation.authors.len(), 1);
     }
 }


### PR DESCRIPTION
Added handling and test case for `PubMedLine::Continuation` of a `TI` field.

Side note: I reviewed `pubmed.rs`, the parser works great though I think a better design would be to parse in stages: what you have right now is a method `PubMedParser::parse` which loops over `input.lines().enumerate()` using mutable variables as accumulators. This loop does too many things and the method if 98 lines long. A better design would be to separate parsing from serialization. Here's some pseudocode:

```rust
fn parse(&self, input: &str) -> Result<Vec<Citation>> {
    // parse PubMed text format to key-value pairs, handling line breaks
    let parsed_input: Vec<HashMap<SmallString, Vec<String>>> = parse_pubmed(input)?;
    // interpret each HashMap of key-value pairs as structured data
    let citations: Vec<Citation> = parsed_input.into_iter().map(serialize_pubmed).collect();
    Ok(citations)
}

// implementation of parse_pubmed and serialize_pubmed are not shown.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced handling of multi-line titles and abstracts in PubMed records to ensure proper spacing and preservation of hyphenation.

- **Tests**
  - Added tests verifying correct concatenation of continued lines and hyphenated breaks in titles and abstracts.

- **Documentation**
  - Updated support links in the README to reflect the new repository owner name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->