### PR TITLE
Remove source tracking from parsers and Citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### BREAKING CHANGES
+
+- **Removed source tracking functionality**: The `source` field has been completely removed from the `Citation` struct and all parser implementations
+- **Removed `with_source()` methods**: All parsers no longer have the `with_source()` method
+- **Updated `detect_and_parse()` function**: Now takes only one parameter (`content`) instead of two (`content`, `source`)
+- **Updated deduplication API**: Added `find_duplicates_with_sources()` method for source-aware deduplication
+
+### Migration Guide
+
+If you were using source tracking in your application, you'll need to handle source tracking at the application level:
+
+**Before (v0.2.x):**
+
+```rust
+let parser = RisParser::new().with_source("PubMed");
+let citations = parser.parse(input).unwrap();
+let source = citations[0].source.clone(); // "PubMed"
+```
+
+**After (v0.3.x):**
+
+```rust
+let parser = RisParser::new();
+let citations = parser.parse(input).unwrap();
+// Handle source tracking in your application:
+let source = "PubMed"; // manage this in your app
+```
+
+**For `detect_and_parse()`:**
+
+```rust
+// Before
+let (citations, format) = detect_and_parse(content, "PubMed").unwrap();
+
+// After
+let (citations, format) = detect_and_parse(content).unwrap();
+// Track source separately in your application
+```
+
+**For deduplication with source preferences:**
+
+```rust
+// Before (using source field in Citation)
+let citations = vec![/* citations with source field */];
+let deduplicator = Deduplicator::new().with_config(config);
+let groups = deduplicator.find_duplicates(&citations).unwrap();
+
+// After (using external source mapping)
+let citations = vec![/* citations without source field */];
+let sources = vec!["PubMed", "CrossRef"]; // source for each citation
+let deduplicator = Deduplicator::new().with_config(config);
+let groups = deduplicator.find_duplicates_with_sources(&citations, &sources).unwrap();
+```
+
 ## [0.2.4] - 2025-06-11
 
 ### Fixed

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,7 +1,6 @@
-//! CSV format parser implementation with source tracking support.
+//! CSV format parser implementation.
 //!
-//! This module provides functionality to parse CSV formatted citations with configurable headers
-//! and built-in source tracking capabilities.
+//! This module provides functionality to parse CSV formatted citations with configurable headers.
 //!
 //! # Example
 //!
@@ -10,12 +9,10 @@
 //!
 //! let input = "Title,Author,Year\nExample Paper,Smith J,2023";
 //!
-//! let parser = CsvParser::new()
-//!     .with_source("Cochrane");
+//! let parser = CsvParser::new();
 //!     
 //! let citations = parser.parse(input).unwrap();
 //! assert_eq!(citations[0].title, "Example Paper");
-//! assert_eq!(citations[0].source.as_deref(), Some("Cochrane"));
 //! ```
 
 use csv::{ReaderBuilder, StringRecord};
@@ -169,7 +166,6 @@ impl CsvConfig {
 #[derive(Debug, Clone)]
 pub struct CsvParser {
     config: CsvConfig,
-    source: Option<String>,
 }
 
 impl Default for CsvParser {
@@ -184,7 +180,6 @@ impl CsvParser {
     pub fn new() -> Self {
         Self {
             config: CsvConfig::new(),
-            source: None,
         }
     }
 
@@ -195,16 +190,9 @@ impl CsvParser {
         self
     }
 
-    #[must_use]
-    pub fn with_source(mut self, source: &str) -> Self {
-        self.source = Some(source.to_string());
-        self
-    }
-
     /// Parses a record into a Citation using the current header mapping
     fn parse_record(&self, headers: &[String], record: StringRecord) -> Result<Citation> {
         let mut citation = Citation {
-            source: self.source.clone(),
             ..Default::default()
         };
         let mut has_id = false;

--- a/src/endnote_xml.rs
+++ b/src/endnote_xml.rs
@@ -1,6 +1,6 @@
-//! EndNote XML format parser implementation with source tracking support.
+//! EndNote XML format parser implementation.
 //!
-//! Provides functionality to parse EndNote XML formatted citations with built-in source tracking.
+//! Provides functionality to parse EndNote XML formatted citations.
 //!
 //! # Example
 //!
@@ -13,12 +13,10 @@
 //! <contributors><authors><author>Smith, John</author></authors></contributors>
 //! </record></records></xml>"#;
 //!
-//! let parser = EndNoteXmlParser::new()
-//!     .with_source("Embase");
+//! let parser = EndNoteXmlParser::new();
 //!     
 //! let citations = parser.parse(input).unwrap();
 //! assert_eq!(citations[0].title, "Example Title");
-//! assert_eq!(citations[0].source.as_deref(), Some("Embase"));
 //! ```
 //!
 //! Visit the [EndNote: XML Document Type Definition](https://support.clarivate.com/Endnote/s/article/EndNote-XML-Document-Type-Definition?language=en_US) for more details.
@@ -36,9 +34,7 @@ use crate::{Author, Citation, CitationError, CitationParser, Result};
 
 /// Parser for EndNote XML format citations.
 #[derive(Debug, Default, Clone)]
-pub struct EndNoteXmlParser {
-    source: Option<String>,
-}
+pub struct EndNoteXmlParser {}
 
 impl EndNoteXmlParser {
     /// Creates a new EndNote XML parser instance.
@@ -51,13 +47,7 @@ impl EndNoteXmlParser {
     /// ```
     #[must_use]
     pub fn new() -> Self {
-        Self { source: None }
-    }
-
-    #[must_use]
-    pub fn with_source(mut self, source: &str) -> Self {
-        self.source = Some(source.to_string());
-        self
+        Self {}
     }
 
     /// Extracts text content from XML events until the closing tag is found
@@ -81,7 +71,7 @@ impl EndNoteXmlParser {
                     return Err(CitationError::InvalidFormat(format!(
                         "Unexpected EOF while looking for closing tag '{}'",
                         closing_tag_str
-                    )))
+                    )));
                 }
                 Err(e) => return Err(CitationError::from(e)),
                 _ => continue,
@@ -154,11 +144,9 @@ impl EndNoteXmlParser {
     ) -> Result<Citation> {
         let mut citation = Citation {
             id: nanoid!(),
-            source: self.source.clone(),
             ..Default::default()
         };
         citation.citation_type.push("Journal Article".to_string()); // Set default type
-        citation.source = self.source.clone(); // Now we can access self.source
 
         loop {
             match reader.read_event_into(buf) {
@@ -258,7 +246,7 @@ impl EndNoteXmlParser {
                                 Ok(Event::End(ref inner_e))
                                     if inner_e.name() == QName(b"dates") =>
                                 {
-                                    break
+                                    break;
                                 }
                                 Ok(Event::Eof) => break,
                                 Err(e) => return Err(CitationError::from(e)),

--- a/src/pubmed.rs
+++ b/src/pubmed.rs
@@ -1,6 +1,6 @@
-//! PubMed format parser implementation with source tracking support.
+//! PubMed format parser implementation.
 //!
-//! Provides functionality to parse PubMed formatted citations with built-in source tracking.
+//! Provides functionality to parse PubMed formatted citations.
 //!
 //! # Example
 //!
@@ -32,9 +32,7 @@ use crate::{Citation, CitationParser, Result};
 /// PubMed format is commonly used by PubMed and the National Library of Medicine
 /// for bibliographic citations.
 #[derive(Debug, Clone, Default)]
-pub struct PubMedParser {
-    source: Option<String>,
-}
+pub struct PubMedParser {}
 
 impl PubMedParser {
     /// Creates a new PubMed parser instance.
@@ -48,12 +46,6 @@ impl PubMedParser {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    #[must_use]
-    pub fn with_source(mut self, source: &str) -> Self {
-        self.source = Some(source.to_string());
-        self
     }
 }
 
@@ -238,7 +230,10 @@ AU  - Van Dyke MCC
         assert_eq!(result.len(), 1);
         let citation = &result[0];
         assert_eq!(citation.pmid.as_deref(), Some("31181385"));
-        assert_eq!(citation.title, "Fantastic yeasts and where to find them: the hidden diversity of dimorphic fungal pathogens.");
+        assert_eq!(
+            citation.title,
+            "Fantastic yeasts and where to find them: the hidden diversity of dimorphic fungal pathogens."
+        );
         assert_eq!(
             result[0].abstract_text.as_deref(),
             Some("This is a long abstract that spans multiple lines for testing purposes.")

--- a/src/pubmed/parse.rs
+++ b/src/pubmed/parse.rs
@@ -1,4 +1,4 @@
-use crate::pubmed::author::{resolve_authors, ConsecutiveTag};
+use crate::pubmed::author::{ConsecutiveTag, resolve_authors};
 use crate::pubmed::structure::RawPubmedData;
 use crate::pubmed::tags::PubmedTag;
 use crate::utils::newline_delimiter_of;

--- a/src/pubmed/structure.rs
+++ b/src/pubmed/structure.rs
@@ -80,9 +80,6 @@ impl TryFrom<RawPubmedData> for crate::Citation {
                 .into_iter()
                 .map(|(k, v)| (k.as_tag().to_string(), v))
                 .collect(),
-
-            // soon to be removed, see https://github.com/AliAzlanDev/biblib/issues/9#issuecomment-2989899194
-            source: None,
         })
     }
 }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,9 +1,9 @@
 //! Re-exports from either `regex` or `regex_lite`, depending on features.
 
-#[cfg(feature = "lite")]
-pub(crate) use regex_lite::{Regex, Captures};
 #[cfg(all(feature = "regex", not(feature = "lite")))]
-pub(crate) use regex::{Regex, Captures};
+pub(crate) use regex::{Captures, Regex};
+#[cfg(feature = "lite")]
+pub(crate) use regex_lite::{Captures, Regex};
 
 #[cfg(not(any(feature = "regex", feature = "lite")))]
 compile_error!("biblib requires the \"regex\" or \"lite\" feature to be enabled");

--- a/src/ris.rs
+++ b/src/ris.rs
@@ -1,6 +1,6 @@
-//! RIS format parser implementation with source tracking support.
+//! RIS format parser implementation.
 //!
-//! Provides functionality to parse RIS formatted citations with built-in source tracking.
+//! Provides functionality to parse RIS formatted citations.
 //!
 //! # Example
 //!
@@ -12,12 +12,10 @@
 //! AU  - Smith, John
 //! ER  -"#;
 //!
-//! let parser = RisParser::new()
-//!     .with_source("Google Scholar");
+//! let parser = RisParser::new();
 //!     
 //! let citations = parser.parse(input).unwrap();
 //! assert_eq!(citations[0].title, "Example Title");
-//! assert_eq!(citations[0].source.as_deref(), Some("Google Scholar"));
 //! ```
 
 use crate::utils::{format_doi, format_page_numbers, parse_author_name, parse_ris_date};
@@ -29,9 +27,7 @@ use nanoid::nanoid;
 /// RIS is a standardized format for bibliographic citations that uses two-letter
 /// tags at the start of each line to denote different citation fields.
 #[derive(Debug, Default, Clone)]
-pub struct RisParser {
-    source: Option<String>,
-}
+pub struct RisParser {}
 
 impl RisParser {
     /// Creates a new RIS parser instance.
@@ -44,12 +40,7 @@ impl RisParser {
     /// ```
     #[must_use]
     pub fn new() -> Self {
-        Self { source: None }
-    }
-
-    pub fn with_source(mut self, source: &str) -> Self {
-        self.source = Some(source.to_string());
-        self
+        Self {}
     }
 
     /// Parses an author string in various formats
@@ -123,10 +114,8 @@ impl CitationParser for RisParser {
         let mut citations = Vec::new();
         let mut current_citation = Citation {
             id: nanoid!(),
-            source: self.source.clone(),
             ..Default::default()
         };
-        current_citation.source = self.source.clone(); // Add source if provided
         let mut start_page = String::new();
 
         for line in input.lines() {


### PR DESCRIPTION
Eliminates the `source` field from the `Citation` struct and all parser implementations, removes all `with_source()` methods, and updates the deduplication API to support source-aware deduplication via `find_duplicates_with_sources()`. The `detect_and_parse()` function now only takes the content parameter. Documentation, examples, and tests have been updated to reflect these breaking changes.