### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 /target
 tarpaulin-report.html
+# Devenv
+.devenv*
+devenv.lock
+devenv.local.nix
+devenv.local.yaml
+.envrc
+devenv.nix
+devenv.yaml
+rust-toolchain.toml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,14 +97,14 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -309,18 +309,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,18 +352,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lite = ["dep:regex-lite"]
 diagnostics = ["dep:ariadne"]
 
 [dependencies]
-thiserror = "2.0.11"
+thiserror = "2.0.18"
 ariadne = { version = "0.6.0", optional = true }
 quick-xml = { version = "0.37.2", optional = true }
 csv = { version = "1.3.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ariadne = { version = "0.6.0", optional = true }
 quick-xml = { version = "0.39.2", optional = true }
 csv = { version = "1.4.0", optional = true }
 strsim = { version = "0.11.1", optional = true }
-rayon = { version = "1.10.0", optional = true }
+rayon = { version = "1.11.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 regex = { version = "1.11.1", optional = true }
 regex-lite = { version = "0.1.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ diagnostics = ["dep:ariadne"]
 [dependencies]
 thiserror = "2.0.18"
 ariadne = { version = "0.6.0", optional = true }
-quick-xml = { version = "0.37.2", optional = true }
+quick-xml = { version = "0.39.2", optional = true }
 csv = { version = "1.4.0", optional = true }
 strsim = { version = "0.11.1", optional = true }
 rayon = { version = "1.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ csv = { version = "1.4.0", optional = true }
 strsim = { version = "0.11.1", optional = true }
 rayon = { version = "1.11.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-regex = { version = "1.11.1", optional = true }
+regex = { version = "1.12.3", optional = true }
 regex-lite = { version = "0.1.6", optional = true }
 either = "1.15.0"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ strsim = { version = "0.11.1", optional = true }
 rayon = { version = "1.11.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 regex = { version = "1.12.3", optional = true }
-regex-lite = { version = "0.1.6", optional = true }
+regex-lite = { version = "0.1.9", optional = true }
 either = "1.15.0"
 itertools = "0.14.0"
 compact_str = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ diagnostics = ["dep:ariadne"]
 thiserror = "2.0.18"
 ariadne = { version = "0.6.0", optional = true }
 quick-xml = { version = "0.37.2", optional = true }
-csv = { version = "1.3.1", optional = true }
+csv = { version = "1.4.0", optional = true }
 strsim = { version = "0.11.1", optional = true }
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/endnote_xml/parse.rs
+++ b/src/endnote_xml/parse.rs
@@ -32,7 +32,7 @@ fn extract_text_with_position<B: BufRead>(
         let current_pos = reader.buffer_position() as usize;
         match reader.read_event_into(buf) {
             Ok(Event::Text(e)) => {
-                text.push_str(&e.unescape().map_err(|e| {
+                text.push_str(&e.xml_content().map_err(|e| {
                     let line_num = buffer_position_to_line_number(content, current_pos);
                     ParseError::at_line(
                         line_num,


### PR DESCRIPTION
Hi, I was looking around lib.rs for good ready-made solutions for handling citation data, and found your crate. Thought I'd pitch in a bit since I noticed that some dependencies were out of date.

This PR updates the following dependencies:
- thiserror (2.0.11 -> 2.0.18)
- quick-xml (0.37.2 -> 0.39.2)
- csv (1.3.1 -> 1.4.0)
- rayon (1.10.0 -> 1.11.0)
- regex (1.11.1 -> 1.12.3)
- regex-lite (0.1.6 -> 0.1.9)

Almost all of them were simple upgrades with no code changes (confirmed through cargo test and cargo check on all features).

However, `quick-xml` has deprecated a method you used. I checked the docs for another option, which seems to pass this project's tests and builds properly. Take a look at it and see if it does what it should (I think it does, but I haven't properly learnt the code structure yet).

PS: The first commit and its changes to `.gitignore` is to exclude some development environment stuff I use, since I didn't want to pollute the repo with dev environment-related stuff.

PPS: I noticed that three tests fail on `cargo test --no-default-features` (which I used to selectively enable features when upgrading their dependencies). If you want, I can make an issue or a PR for it, but I left it as-is for this PR to keep things organized.