### PR TITLE
Add ICTRP parser and accession number support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-24
+
+### Added
+
+- **`accession_number` on `Citation`**: Added a new normalized identifier field for registry and source accession values.
+- **ICTRP CSV parser**: Added `IctrpCsvParser` for WHO ICTRP CSV exports from the [WHO International Clinical Trials Registry Platform (ICTRP)](https://www.who.int/tools/clinical-trials-registry-platform), plus narrow ICTRP auto-detection in `detect_and_parse()`.
+- **RIS accession-number mapping**: RIS `AN` now maps to `Citation.accession_number`.
+- **EndNote XML accession-number mapping**: EndNote XML `<accession-num>` now maps to `Citation.accession_number`.
+
+### Changed
+
+- **Regex backend simplified**: `biblib` no longer exposes public `regex` or `lite` feature flags. As of `v0.5`, the crate uses `regex-lite` internally.
+- **Versioning impact**: This release is breaking for downstream code that constructs `Citation` with struct literals or exhaustively matches `CitationFormat`.
+- **`CitationFormat` expanded**: Added `CitationFormat::IctrpCsv`.
+- **README and crate-level docs rewritten**: Documentation was updated to match the normalized model, parser surface, and current feature flags.
+
+### Migration Guide
+
+#### `Citation` struct literal construction
+
+If you construct `Citation` values directly with struct literals, add the new `accession_number` field:
+
+```rust
+// Before (0.4.x):
+Citation {
+    title: "Example".into(),
+    doi: Some("10.1000/example".into()),
+    ..Default::default()
+}
+
+// After (0.5.x):
+Citation {
+    title: "Example".into(),
+    doi: Some("10.1000/example".into()),
+    accession_number: None,
+    ..Default::default()
+}
+```
+
+#### `CitationFormat` exhaustive matches
+
+If you match every `CitationFormat` variant, add a branch for `CitationFormat::IctrpCsv`.
+
 ## [0.4.4] - 2026-06-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "biblib"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ariadne",
  "compact_str",
@@ -33,7 +33,6 @@ dependencies = [
  "pretty_assertions",
  "quick-xml",
  "rayon",
- "regex",
  "regex-lite",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biblib"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 description = "Parse, manage, and deduplicate academic citations"
 authors = ["Ali Azlan <aliazlanofficial@gmail.com>"]
@@ -12,14 +12,12 @@ keywords = ["citations", "deduplication", "nbib", "doi", "bibliography"]
 categories = ["science", "text-processing"]
 
 [features]
-default = ["csv", "pubmed", "xml", "ris", "dedupe", "regex"]
+default = ["csv", "pubmed", "xml", "ris", "dedupe"]
 csv = ["dep:csv"]
 pubmed = []
 xml = ["dep:quick-xml"]
 ris = []
 dedupe = ["dep:rayon", "dep:strsim"]
-regex = ["dep:regex"]
-lite = ["dep:regex-lite"]
 diagnostics = ["dep:ariadne"]
 
 [dependencies]
@@ -30,8 +28,7 @@ csv = { version = "1.4.0", optional = true }
 strsim = { version = "0.11.1", optional = true }
 rayon = { version = "1.11.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-regex = { version = "1.12.3", optional = true }
-regex-lite = { version = "0.1.9", optional = true }
+regex-lite = "0.1.9"
 either = "1.15.0"
 itertools = "0.14.0"
 compact_str = "0.9.0"

--- a/PARSING_GUIDE.md
+++ b/PARSING_GUIDE.md
@@ -33,10 +33,12 @@ RIS (Research Information Systems) uses two-letter tags to identify fields. Each
 | IS | Issue | |
 | SP, EP | Start/End page | Combined into page range |
 | DO | DOI | |
+| AN | Accession number | Mapped to `accession_number` |
 | AB, N2 | Abstract | AB takes priority |
 | KW | Keywords | One per line |
 | SN | ISSN/ISBN | |
 | UR, L1-L4, LK | URLs | All collected |
+| ID | Reference ID | Preserved in `extra_fields` |
 | ER | End of reference | Marks end of record |
 
 ### Multi-Author Handling
@@ -164,6 +166,7 @@ EndNote XML uses a nested XML structure with specific element names.
 | `<number>` | Issue | |
 | `<pages>` | Pages | |
 | `<electronic-resource-num>` | DOI | |
+| `<accession-num>` | Accession number | |
 | `<url>` | URL | |
 | `<abstract>` | Abstract | |
 | `<keyword>` | Keywords | Inside `<keywords>` |
@@ -217,6 +220,34 @@ Authors
 ```
 
 Results in 3 separate authors.
+
+---
+
+## ICTRP CSV Format
+
+ICTRP exports are parsed by the dedicated `IctrpCsvParser`, which reuses the CSV reader but applies ICTRP-specific field mapping.
+
+### Key Field Mappings
+
+| ICTRP Column | Field | Notes |
+|--------------|-------|-------|
+| `TrialID` | `accession_number` | Required canonical registry identifier |
+| `Scientific title` | `title` | Primary title |
+| `Public title` | `title` fallback | Also preserved in `extra_fields` |
+| `Date registration3` | `date` | Preferred compact `YYYYMMDD` source |
+| `Date registration` | `date` fallback | Supports slash-separated dates |
+| `Primary sponsor` | `publisher` | |
+| `Study type` | `citation_type` | Stored after `Clinical Trial` when present |
+| `web address` | `urls` | Deduplicated with results URLs |
+| `results url link` | `urls` | |
+| `results url protocol` | `urls` | |
+| `Secondary ID` | `extra_fields` | Preserved raw |
+
+### Notes
+
+- `citation_type` always starts with `Clinical Trial`; `Study type` is appended second when present and distinct.
+- `authors` is left empty because ICTRP exports sponsor and contact metadata rather than article authors.
+- Remaining non-empty ICTRP columns are preserved in `extra_fields`.
 
 ### Auto-Detection
 

--- a/README.md
+++ b/README.md
@@ -4,194 +4,270 @@
 [![Documentation](https://docs.rs/biblib/badge.svg)](https://docs.rs/biblib)
 [![License](https://img.shields.io/crates/l/biblib.svg)](LICENSE-MIT)
 
-A Rust library for parsing and deduplicating academic citations.
+`biblib` is a Rust library for parsing citation exports into a shared data model and deduplicating the resulting records.
+
+It is built for import pipelines, evidence synthesis tooling, registry ingestion, and any workflow that needs to turn citation files from multiple sources into one normalized `Citation` shape.
+
+## What It Supports
+
+`biblib` currently ships parsers for:
+
+| Source format | Feature | Parser |
+| --- | --- | --- |
+| RIS | `ris` | `RisParser` |
+| PubMed / MEDLINE (`.nbib`) | `pubmed` | `PubMedParser` |
+| EndNote XML | `xml` | `EndNoteXmlParser` |
+| Generic CSV / delimited data | `csv` | `csv::CsvParser` |
+| ICTRP registry CSV exports | `csv` | `IctrpCsvParser` |
+
+All parser outputs converge on the same `Citation` struct, including normalized fields such as `title`, `authors`, `date`, `doi`, `accession_number`, `pmid`, `pmc_id`, `urls`, and `extra_fields`.
 
 ## Installation
 
 ```toml
 [dependencies]
-biblib = "0.4"
+biblib = "0.5"
 ```
 
-For minimal builds:
+For a smaller build:
 
 ```toml
 [dependencies]
-biblib = { version = "0.4", default-features = false, features = ["ris", "regex"] }
+biblib = { version = "0.5", default-features = false, features = ["ris"] }
 ```
-
-## Supported Formats
-
-| Format      | Feature  | Description                         |
-| ----------- | -------- | ----------------------------------- |
-| RIS         | `ris`    | Research Information Systems format |
-| PubMed      | `pubmed` | MEDLINE/PubMed `.nbib` files        |
-| EndNote XML | `xml`    | EndNote XML export format           |
-| CSV         | `csv`    | Configurable delimited files        |
-
-All format features are enabled by default.
 
 ## Quick Start
 
-### Parsing Citations
+### Parse RIS
 
 ```rust
 use biblib::{CitationParser, RisParser};
 
-let ris_content = r#"TY  - JOUR
+let input = r#"TY  - JOUR
 TI  - Machine Learning in Healthcare
 AU  - Smith, John
 AU  - Doe, Jane
 PY  - 2023
+DO  - 10.1000/example
 ER  -"#;
 
-let parser = RisParser::new();
-let citations = parser.parse(ris_content).unwrap();
+let citations = RisParser::new().parse(input).unwrap();
 
-println!("Title: {}", citations[0].title);
-println!("Authors: {:?}", citations[0].authors);
+assert_eq!(citations.len(), 1);
+assert_eq!(citations[0].title, "Machine Learning in Healthcare");
+assert_eq!(citations[0].doi.as_deref(), Some("10.1000/example"));
 ```
 
-### Auto-Detecting Format
+### Parse PubMed / MEDLINE
+
+```rust
+use biblib::{CitationParser, PubMedParser};
+
+let input = r#"PMID- 12345678
+TI  - Immunotherapy in Oncology
+FAU - Smith, John
+JT  - Journal of Clinical Research
+DP  - 2024 Jun 15
+AB  - Example abstract."#;
+
+let citations = PubMedParser::new().parse(input).unwrap();
+
+assert_eq!(citations.len(), 1);
+assert_eq!(citations[0].pmid.as_deref(), Some("12345678"));
+assert_eq!(citations[0].title, "Immunotherapy in Oncology");
+assert_eq!(citations[0].journal.as_deref(), Some("Journal of Clinical Research"));
+```
+
+### Auto-detect Supported Formats
+
+`detect_and_parse()` currently auto-detects RIS, PubMed, EndNote XML, and ICTRP CSV. Generic CSV should still be parsed explicitly with `CsvParser`.
 
 ```rust
 use biblib::detect_and_parse;
 
-let content = "TY  - JOUR\nTI  - Example\nER  -";
-let (citations, format) = detect_and_parse(content).unwrap();
+let input = "TY  - JOUR\nTI  - Example\nER  -";
+let (citations, format) = detect_and_parse(input).unwrap();
 
-println!("Detected format: {}", format); // "RIS"
+assert_eq!(format.as_str(), "RIS");
+assert_eq!(citations[0].title, "Example");
 ```
 
-### Deduplicating Citations
+### Parse ICTRP CSV
 
 ```rust
-use biblib::dedupe::{Deduplicator, DeduplicatorConfig};
+use biblib::{CitationParser, IctrpCsvParser};
 
-let config = DeduplicatorConfig {
-    group_by_year: true,      // Group by year for performance
-    run_in_parallel: true,    // Use parallel processing
-    source_preferences: vec!["PubMed".to_string()], // Prefer PubMed records
-};
+let input = concat!(
+    "TrialID,Public title,Scientific title,Date registration,Date registration3,Study type,Source Register\n",
+    "NCT00000001,Public title,Scientific title,01/05/2026,20260501,Interventional,ClinicalTrials.gov\n"
+);
 
-let deduplicator = Deduplicator::new().with_config(config);
-let groups = deduplicator.find_duplicates(&citations).unwrap();
+let citations = IctrpCsvParser::new().parse(input).unwrap();
+let citation = &citations[0];
 
-for group in groups {
-    if !group.duplicates.is_empty() {
-        println!("Kept: {}", group.unique.title);
-        println!("Duplicates: {}", group.duplicates.len());
-    }
-}
+assert_eq!(citation.accession_number.as_deref(), Some("NCT00000001"));
+assert_eq!(citation.title, "Scientific title");
+assert_eq!(citation.citation_type, vec!["Clinical Trial", "Interventional"]);
 ```
 
-### CSV with Custom Headers
+### Parse Generic CSV with Custom Headers
 
 ```rust
-use biblib::csv::{CsvParser, CsvConfig};
+use biblib::csv::{CsvConfig, CsvParser};
 use biblib::CitationParser;
 
 let mut config = CsvConfig::new();
 config
     .set_delimiter(b';')
     .set_header_mapping("title", vec!["Article Name".to_string()])
-    .set_header_mapping("authors", vec!["Writers".to_string()]);
+    .set_header_mapping("authors", vec!["Writers".to_string()])
+    .set_header_mapping("year", vec!["Published".to_string()]);
 
-let parser = CsvParser::with_config(config);
-let citations = parser.parse("Article Name;Writers\nMy Paper;Smith J").unwrap();
+let input = "Article Name;Writers;Published\nExample Paper;Smith, John;2023";
+let citations = CsvParser::with_config(config).parse(input).unwrap();
+
+assert_eq!(citations[0].title, "Example Paper");
+assert_eq!(citations[0].date.as_ref().unwrap().year, 2023);
 ```
 
-## Citation Fields
+### Deduplicate Parsed Records
 
-Each parsed citation contains:
+```rust
+use biblib::dedupe::{Deduplicator, DeduplicatorConfig};
+use biblib::{Citation, Date};
 
-| Field           | Type             | Description                                 |
-| --------------- | ---------------- | ------------------------------------------- |
-| `title`         | `String`         | Work title                                  |
-| `authors`       | `Vec<Author>`    | Authors with name, given name, affiliations |
-| `journal`       | `Option<String>` | Full journal name                           |
-| `journal_abbr`  | `Option<String>` | Journal abbreviation                        |
-| `date`          | `Option<Date>`   | Year, month, day                            |
-| `volume`        | `Option<String>` | Volume number                               |
-| `issue`         | `Option<String>` | Issue number                                |
-| `pages`         | `Option<String>` | Page range                                  |
-| `doi`           | `Option<String>` | Digital Object Identifier                   |
-| `pmid`          | `Option<String>` | PubMed ID                                   |
-| `pmc_id`        | `Option<String>` | PubMed Central ID                           |
-| `issn`          | `Vec<String>`    | ISSNs                                       |
-| `abstract_text` | `Option<String>` | Abstract                                    |
-| `keywords`      | `Vec<String>`    | Keywords                                    |
-| `urls`          | `Vec<String>`    | Related URLs                                |
-| `mesh_terms`    | `Vec<String>`    | MeSH terms (PubMed)                         |
-| `extra_fields`  | `HashMap`        | Additional format-specific fields           |
+let citations = vec![
+    Citation {
+        title: "Example Title".to_string(),
+        doi: Some("10.1000/example".to_string()),
+        date: Some(Date { year: 2023, month: None, day: None }),
+        journal: Some("Example Journal".to_string()),
+        ..Default::default()
+    },
+    Citation {
+        title: "Example Title".to_string(),
+        doi: Some("10.1000/example".to_string()),
+        date: Some(Date { year: 2023, month: None, day: None }),
+        journal: Some("Example Journal".to_string()),
+        ..Default::default()
+    },
+];
 
-## Features
+let config = DeduplicatorConfig {
+    group_by_year: true,
+    run_in_parallel: true,
+    source_preferences: vec!["PubMed".to_string()],
+};
 
-| Feature       | Dependencies      | Description                                       |
-| ------------- | ----------------- | ------------------------------------------------- |
-| `ris`         | -                 | RIS format parser                                 |
-| `pubmed`      | -                 | PubMed/MEDLINE parser                             |
-| `xml`         | `quick-xml`       | EndNote XML parser                                |
-| `csv`         | `csv`             | CSV parser                                        |
-| `dedupe`      | `rayon`, `strsim` | Deduplication engine                              |
-| `regex`       | `regex`           | Full regex support                                |
-| `lite`        | `regex-lite`      | Lightweight regex (smaller binary)                |
-| `diagnostics` | `ariadne`         | Pretty, coloured error output with source context |
+let groups = Deduplicator::new()
+    .with_config(config)
+    .find_duplicates(&citations)
+    .unwrap();
 
-Default: all features enabled except `lite` and `diagnostics`.
+let duplicate_group = groups
+    .iter()
+    .find(|group| group.unique.doi.as_deref() == Some("10.1000/example"))
+    .unwrap();
 
-> **Note:** At least one of `regex` or `lite` must always be enabled — the crate will not compile without one of them. They are mutually exclusive; do not enable both.
+assert_eq!(duplicate_group.duplicates.len(), 1);
+```
 
-## Error Handling
+## Data Model
 
-All parse errors carry a 1-based line number and, where available, a byte-offset span pointing to the problematic citation record:
+The core output type is `Citation`.
+
+Important fields include:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `citation_type` | `Vec<String>` | Source and work-type labels |
+| `title` | `String` | Main normalized title |
+| `authors` | `Vec<Author>` | Parsed people with name parts and affiliations |
+| `journal` | `Option<String>` | Full journal or source title |
+| `journal_abbr` | `Option<String>` | Journal abbreviation |
+| `date` | `Option<Date>` | Year with optional month/day |
+| `volume` | `Option<String>` | Volume string |
+| `issue` | `Option<String>` | Issue or number string |
+| `pages` | `Option<String>` | Normalized page range |
+| `issn` | `Vec<String>` | One or more ISSNs/serial identifiers |
+| `doi` | `Option<String>` | Normalized DOI |
+| `accession_number` | `Option<String>` | Registry or source accession identifier |
+| `pmid` | `Option<String>` | PubMed identifier |
+| `pmc_id` | `Option<String>` | PubMed Central identifier |
+| `abstract_text` | `Option<String>` | Abstract text |
+| `keywords` | `Vec<String>` | Parsed keywords |
+| `urls` | `Vec<String>` | Collected links |
+| `language` | `Option<String>` | Language code or label |
+| `mesh_terms` | `Vec<String>` | PubMed MeSH terms |
+| `publisher` | `Option<String>` | Publisher or sponsor |
+| `extra_fields` | `HashMap<String, Vec<String>>` | Source-specific leftovers preserved raw |
+
+This makes it easy to normalize aggressively where the library has clear semantics, while still keeping source-specific information available.
+
+## Feature Flags
+
+| Feature | Enables |
+| --- | --- |
+| `ris` | RIS parser |
+| `pubmed` | PubMed / MEDLINE parser |
+| `xml` | EndNote XML parser |
+| `csv` | Generic CSV parser and ICTRP CSV parser |
+| `dedupe` | Deduplication engine |
+| `diagnostics` | Pretty parse diagnostics via `ariadne` |
+
+Default features: `csv`, `pubmed`, `xml`, `ris`, `dedupe`
+
+Since `v0.5`, `biblib` no longer uses the `regex` crate or exposes regex-backend feature flags. It uses `regex-lite` internally, and regex backend selection is no longer part of the public API surface.
+
+## Errors and Diagnostics
+
+All parsers return `ParseError` on malformed input. Errors carry:
+
+- The source format
+- A 1-based line number when available
+- A byte span when available
+- A structured `ValueError`
+
+Example:
 
 ```rust
 use biblib::{CitationParser, RisParser, ValueError};
 
+let input = "TY  - JOUR\nAU  - Smith, John\nER  -\n";
+
 match RisParser::new().parse(input) {
-    Ok(citations) => println!("Parsed {} citations", citations.len()),
-    Err(e) => {
-        eprintln!("Parse error: {}", e); // includes "at line N" when known
-        if let ValueError::MissingValue { key, .. } = &e.error {
-            eprintln!("Missing required field: {}", key);
-        }
+    Ok(_) => unreachable!("expected a parse error"),
+    Err(err) => {
+        assert_eq!(err.line, Some(1));
+        assert!(matches!(err.error, ValueError::MissingValue { key: "TI", .. }));
     }
 }
 ```
 
-### Pretty diagnostics (optional)
-
-Enable the `diagnostics` feature for human-friendly, coloured output powered by [ariadne](https://crates.io/crates/ariadne):
+For human-friendly diagnostics, enable `diagnostics`:
 
 ```toml
 [dependencies]
-biblib = { version = "0.4", features = ["diagnostics"] }
+biblib = { version = "0.5", features = ["diagnostics"] }
 ```
+
+Then use `parse_with_diagnostics()`:
 
 ```rust
 use biblib::{RisParser, parse_with_diagnostics};
 
-let source = std::fs::read_to_string("citations.ris")?;
-match parse_with_diagnostics(&RisParser::new(), &source, "citations.ris") {
-    Ok(citations) => println!("Parsed {} citations", citations.len()),
-    Err(diagnostic) => eprintln!("{}", diagnostic),
-    // Error: Error in RIS format at line 5: Missing value for TI
-    //    ╭─[citations.ris:5:1]
-    //  5 │ TY  - JOUR
-    //    │ ──────────── Missing value for TI
-    //    ╰───
-}
+let input = "TY  - JOUR\nAU  - Smith, John\nER  -\n";
+let rendered = parse_with_diagnostics(&RisParser::new(), input, "refs.ris");
+
+assert!(rendered.is_err());
 ```
 
-You can also call `error.to_diagnostic(filename, source)` directly on any `ParseError`.
+## Guides
 
-## Documentation
-
-- **[Parsing Guide](PARSING_GUIDE.md)** — Format-specific tag mappings, date formats, and author handling
-- **[Deduplication Guide](DEDUPLICATION_GUIDE.md)** — Matching algorithm, similarity thresholds, and configuration
-- **[API Docs](https://docs.rs/biblib)** — Complete API reference
+- [PARSING_GUIDE.md](PARSING_GUIDE.md) - format-specific mapping and normalization rules
+- [DEDUPLICATION_GUIDE.md](DEDUPLICATION_GUIDE.md) - duplicate matching behavior and configuration
+- [docs.rs/biblib](https://docs.rs/biblib) - API reference
 
 ## License
 
-Licensed under either of [Apache License 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) at your option.
+Licensed under either [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE), at your option.

--- a/src/csv/config.rs
+++ b/src/csv/config.rs
@@ -18,6 +18,10 @@ pub(crate) const DEFAULT_HEADERS: &[(&str, &[&str])] = &[
     ("issue", &["issue", "number", "no"]),
     ("pages", &["pages", "page numbers", "page range"]),
     ("doi", &["doi", "digital object identifier"]),
+    (
+        "accession_number",
+        &["accession number", "accession_number"],
+    ),
     ("abstract", &["abstract", "summary"]),
     ("keywords", &["keywords", "tags"]),
     ("issn", &["issn"]),

--- a/src/csv/ictrp.rs
+++ b/src/csv/ictrp.rs
@@ -1,0 +1,304 @@
+use crate::csv::config::CsvConfig;
+use crate::csv::parse::csv_parse_with_format;
+use crate::csv::structure::RawCsvData;
+use crate::error::{ParseError, SourceSpan, ValueError, fields};
+use crate::{Citation, CitationFormat, CitationParser, Date};
+use csv::ReaderBuilder;
+use std::collections::HashMap;
+
+/// Parser for ICTRP CSV exports.
+#[derive(Debug, Clone, Default)]
+pub struct IctrpCsvParser;
+
+impl IctrpCsvParser {
+    /// Creates a new ICTRP CSV parser.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn config() -> CsvConfig {
+        let mut config = CsvConfig::new();
+        config
+            .set_header_mapping("accession_number", vec!["TrialID".to_string()])
+            .set_header_mapping("scientific_title", vec!["Scientific title".to_string()])
+            .set_header_mapping("date_registration", vec!["Date registration".to_string()])
+            .set_header_mapping(
+                "date_registration_compact",
+                vec!["Date registration3".to_string()],
+            )
+            .set_header_mapping("publisher", vec!["Primary sponsor".to_string()])
+            .set_header_mapping("type", vec!["Study type".to_string()])
+            .set_header_mapping(
+                "url",
+                vec![
+                    "web address".to_string(),
+                    "results url link".to_string(),
+                    "results url protocol".to_string(),
+                ],
+            );
+        config
+    }
+}
+
+impl CitationParser for IctrpCsvParser {
+    fn parse(&self, input: &str) -> Result<Vec<Citation>, ParseError> {
+        let config = Self::config();
+        let raw_citations = csv_parse_with_format(input, &config, CitationFormat::IctrpCsv)?;
+
+        raw_citations
+            .into_iter()
+            .map(RawCsvData::into_ictrp_citation)
+            .collect()
+    }
+}
+
+pub(crate) fn looks_like_ictrp_csv(content: &str) -> bool {
+    let mut reader = ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(content.as_bytes());
+
+    let Ok(headers) = reader.headers() else {
+        return false;
+    };
+
+    let header_names = headers
+        .iter()
+        .map(|header| header.trim().to_ascii_lowercase())
+        .collect::<Vec<_>>();
+
+    let has_trial_id = header_names.iter().any(|header| header == "trialid");
+    let has_source_register = header_names
+        .iter()
+        .any(|header| header == "source register");
+    let has_title = header_names
+        .iter()
+        .any(|header| header == "scientific title" || header == "public title");
+    let has_registration_date = header_names
+        .iter()
+        .any(|header| header == "date registration" || header == "date registration3");
+
+    has_trial_id && has_source_register && has_title && has_registration_date
+}
+
+impl RawCsvData {
+    pub(crate) fn into_ictrp_citation(mut self) -> Result<Citation, ParseError> {
+        let accession_number = self
+            .fields
+            .remove("accession_number")
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                ParseError::at_line(
+                    self.line_number,
+                    CitationFormat::IctrpCsv,
+                    ValueError::MissingValue {
+                        field: fields::ACCESSION_NUMBER,
+                        key: "TrialID",
+                    },
+                )
+                .with_span(SourceSpan::new(self.byte_offset, self.byte_offset))
+            })?;
+
+        let scientific_title = self
+            .fields
+            .remove("scientific_title")
+            .filter(|value| !value.trim().is_empty());
+        let public_title = self.get_field("Public title").cloned();
+        let title = scientific_title
+            .clone()
+            .or_else(|| {
+                public_title
+                    .clone()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .ok_or_else(|| {
+                ParseError::at_line(
+                    self.line_number,
+                    CitationFormat::IctrpCsv,
+                    ValueError::MissingValue {
+                        field: fields::TITLE,
+                        key: "Scientific title/Public title",
+                    },
+                )
+                .with_span(SourceSpan::new(self.byte_offset, self.byte_offset))
+            })?;
+
+        let date = self
+            .fields
+            .remove("date_registration_compact")
+            .and_then(|value| parse_ictrp_compact_date(&value))
+            .or_else(|| {
+                self.fields
+                    .remove("date_registration")
+                    .and_then(|value| parse_ictrp_slash_date(&value))
+            });
+
+        let publisher = self.fields.remove("publisher");
+        let mut citation_type = vec!["Clinical Trial".to_string()];
+        if let Some(study_type) = self.fields.remove("type")
+            && !study_type.trim().is_empty()
+            && study_type != "Clinical Trial"
+        {
+            citation_type.push(study_type);
+        }
+
+        let mut extra_fields = HashMap::new();
+        for (key, value) in self.fields {
+            if value.trim().is_empty() {
+                continue;
+            }
+            extra_fields.insert(key, vec![value]);
+        }
+
+        Ok(Citation {
+            citation_type,
+            title,
+            authors: Vec::new(),
+            journal: None,
+            journal_abbr: None,
+            date,
+            volume: None,
+            issue: None,
+            pages: None,
+            issn: Vec::new(),
+            doi: None,
+            accession_number: Some(accession_number),
+            pmid: None,
+            pmc_id: None,
+            abstract_text: None,
+            keywords: Vec::new(),
+            urls: dedupe_urls(self.urls),
+            language: None,
+            mesh_terms: Vec::new(),
+            publisher,
+            extra_fields,
+        })
+    }
+}
+
+fn dedupe_urls(urls: Vec<String>) -> Vec<String> {
+    let mut unique = Vec::new();
+    for url in urls {
+        if !url.trim().is_empty() && !unique.contains(&url) {
+            unique.push(url);
+        }
+    }
+    unique
+}
+
+fn parse_ictrp_compact_date(value: &str) -> Option<Date> {
+    let trimmed = value.trim();
+    if trimmed.len() != 8 {
+        return None;
+    }
+
+    let year = trimmed[0..4].parse().ok()?;
+    let month = trimmed[4..6].parse().ok()?;
+    let day = trimmed[6..8].parse().ok()?;
+
+    Some(Date {
+        year,
+        month: Some(month),
+        day: Some(day),
+    })
+}
+
+fn parse_ictrp_slash_date(value: &str) -> Option<Date> {
+    let parts = value.trim().split('/').map(str::trim).collect::<Vec<_>>();
+
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let (year, month, day) = if parts[0].len() == 4 {
+        (
+            parts[0].parse().ok()?,
+            parts[1].parse().ok()?,
+            parts[2].parse().ok()?,
+        )
+    } else {
+        (
+            parts[2].parse().ok()?,
+            parts[1].parse().ok()?,
+            parts[0].parse().ok()?,
+        )
+    };
+
+    Some(Date {
+        year,
+        month: Some(month),
+        day: Some(day),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_looks_like_ictrp_csv() {
+        let input = concat!(
+            "TrialID,Public title,Scientific title,Date registration,Source Register\n",
+            "NCT00000001,Public,Scientific,01/05/2026,ClinicalTrials.gov\n"
+        );
+
+        assert!(looks_like_ictrp_csv(input));
+    }
+
+    #[test]
+    fn test_parse_ictrp_csv() {
+        let input = concat!(
+            "TrialID,Public title,Scientific title,Primary sponsor,Date registration,Date registration3,Study type,web address,results url link,Secondary ID,Source Register\n",
+            "NCT00000001,Public title,Scientific title,Sponsor,01/05/2026,20260501,Interventional,https://example.test/study,https://example.test/results,ABC-123,ClinicalTrials.gov\n"
+        );
+
+        let citation = IctrpCsvParser::new().parse(input).unwrap().remove(0);
+        assert_eq!(citation.accession_number.as_deref(), Some("NCT00000001"));
+        assert_eq!(citation.title, "Scientific title");
+        assert_eq!(citation.publisher.as_deref(), Some("Sponsor"));
+        assert_eq!(
+            citation.citation_type,
+            vec!["Clinical Trial", "Interventional"]
+        );
+        assert_eq!(
+            citation.date,
+            Some(Date {
+                year: 2026,
+                month: Some(5),
+                day: Some(1)
+            })
+        );
+        assert_eq!(
+            citation.extra_fields.get("Public title").unwrap(),
+            &vec!["Public title".to_string()]
+        );
+        assert_eq!(
+            citation.extra_fields.get("Secondary ID").unwrap(),
+            &vec!["ABC-123".to_string()]
+        );
+        assert_eq!(citation.urls.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_ictrp_public_title_fallback() {
+        let input = concat!(
+            "TrialID,Public title,Scientific title,Date registration,Source Register\n",
+            "NCT00000002,Public title,,01/05/2026,ClinicalTrials.gov\n"
+        );
+
+        let citation = IctrpCsvParser::new().parse(input).unwrap().remove(0);
+        assert_eq!(citation.title, "Public title");
+        assert_eq!(citation.citation_type, vec!["Clinical Trial"]);
+    }
+
+    #[test]
+    fn test_parse_ictrp_does_not_duplicate_clinical_trial_type() {
+        let input = concat!(
+            "TrialID,Public title,Scientific title,Study type,Date registration,Source Register\n",
+            "NCT00000003,Public title,Scientific title,Clinical Trial,01/05/2026,ClinicalTrials.gov\n"
+        );
+
+        let citation = IctrpCsvParser::new().parse(input).unwrap().remove(0);
+        assert_eq!(citation.citation_type, vec!["Clinical Trial"]);
+    }
+}

--- a/src/csv/mod.rs
+++ b/src/csv/mod.rs
@@ -17,11 +17,14 @@
 //! ```
 
 mod config;
+mod ictrp;
 mod parse;
 mod structure;
 
 use crate::{Citation, CitationFormat, CitationParser};
 pub use config::CsvConfig;
+pub use ictrp::IctrpCsvParser;
+pub(crate) use ictrp::looks_like_ictrp_csv;
 use parse::csv_parse;
 
 /// Parser for CSV-formatted citation data with configurable mappings.

--- a/src/csv/parse.rs
+++ b/src/csv/parse.rs
@@ -13,6 +13,15 @@ pub fn csv_parse<S: AsRef<str>>(
     csv_text: S,
     config: &CsvConfig,
 ) -> Result<Vec<RawCsvData>, ParseError> {
+    csv_parse_with_format(csv_text, config, CitationFormat::Csv)
+}
+
+/// Parse CSV content while attributing errors to a specific format.
+pub(crate) fn csv_parse_with_format<S: AsRef<str>>(
+    csv_text: S,
+    config: &CsvConfig,
+    format: CitationFormat,
+) -> Result<Vec<RawCsvData>, ParseError> {
     let text = csv_text.as_ref();
 
     if text.trim().is_empty() {
@@ -22,7 +31,7 @@ pub fn csv_parse<S: AsRef<str>>(
     // Validate configuration
     config.validate().map_err(|msg| {
         ParseError::without_position(
-            CitationFormat::Csv,
+            format.clone(),
             ValueError::Syntax(format!("Invalid CSV configuration: {}", msg)),
         )
     })?;
@@ -44,7 +53,7 @@ pub fn csv_parse<S: AsRef<str>>(
             .headers()
             .map_err(|e| {
                 ParseError::without_position(
-                    CitationFormat::Csv,
+                    format.clone(),
                     ValueError::Syntax(format!("Header parsing error: {}", e)),
                 )
             })?
@@ -55,7 +64,7 @@ pub fn csv_parse<S: AsRef<str>>(
         // Use column numbers as headers if no headers present
         let first_record = reader.headers().map_err(|e| {
             ParseError::without_position(
-                CitationFormat::Csv,
+                format.clone(),
                 ValueError::Syntax(format!("Failed to read first record: {}", e)),
             )
         })?;
@@ -66,7 +75,7 @@ pub fn csv_parse<S: AsRef<str>>(
 
     if headers.is_empty() {
         return Err(ParseError::without_position(
-            CitationFormat::Csv,
+            format.clone(),
             ValueError::Syntax("No headers found in CSV".to_string()),
         ));
     }
@@ -80,13 +89,13 @@ pub fn csv_parse<S: AsRef<str>>(
             if let Some(position) = e.position() {
                 ParseError::at_line(
                     position.line() as usize,
-                    CitationFormat::Csv,
+                    format.clone(),
                     ValueError::Syntax(format!("CSV parsing error: {}", e)),
                 )
             } else {
                 ParseError::at_line(
                     line_number,
-                    CitationFormat::Csv,
+                    format.clone(),
                     ValueError::Syntax(format!("CSV parsing error: {}", e)),
                 )
             }
@@ -100,14 +109,14 @@ pub fn csv_parse<S: AsRef<str>>(
         let byte_offset = record.position().map(|p| p.byte() as usize).unwrap_or(0);
 
         let raw_citation =
-            RawCsvData::from_record(&headers, &record, config, line_number, byte_offset)?;
+            RawCsvData::from_record(&headers, &record, config, line_number, byte_offset, &format)?;
 
         if raw_citation.has_content() {
             raw_citations.push(raw_citation);
         } else if !config.flexible {
             return Err(ParseError::at_line(
                 line_number,
-                CitationFormat::Csv,
+                format.clone(),
                 ValueError::Syntax("Record contains no meaningful content".to_string()),
             ));
         }

--- a/src/csv/structure.rs
+++ b/src/csv/structure.rs
@@ -38,6 +38,7 @@ impl RawCsvData {
         config: &CsvConfig,
         line_number: usize,
         byte_offset: usize,
+        format: &CitationFormat,
     ) -> Result<Self, ParseError> {
         let mut fields = HashMap::new();
         let mut authors = Vec::new();
@@ -57,7 +58,7 @@ impl RawCsvData {
                 if !config.flexible {
                     return Err(ParseError::at_line(
                         line_number,
-                        CitationFormat::Csv,
+                        format.clone(),
                         ValueError::Syntax(format!(
                             "Record has more fields ({}) than headers ({})",
                             record.len(),
@@ -194,6 +195,7 @@ impl RawCsvData {
             pages,
             issn: self.issn.clone(),
             doi,
+            accession_number: self.get_field("accession_number").cloned(),
             pmid: self.get_field("pmid").cloned(),
             pmc_id: self.get_field("pmc_id").cloned(),
             abstract_text,
@@ -243,6 +245,7 @@ fn is_standard_field(field_name: &str, config: &CsvConfig) -> bool {
         "issue",
         "pages",
         "doi",
+        "accession_number",
         "pmid",
         "pmc_id",
         "abstract",
@@ -289,7 +292,8 @@ mod tests {
         let record = create_test_record(&["Test Article", "Smith, John"]);
         let config = CsvConfig::new();
 
-        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0).unwrap();
+        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv)
+            .unwrap();
 
         assert_eq!(raw.get_field("title"), Some(&"Test Article".to_string()));
         assert_eq!(raw.authors.len(), 1);
@@ -303,7 +307,8 @@ mod tests {
         let record = create_test_record(&["Smith, John; Doe, Jane"]);
         let config = CsvConfig::new();
 
-        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0).unwrap();
+        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv)
+            .unwrap();
 
         assert_eq!(raw.authors.len(), 2);
         assert_eq!(raw.authors[0].name, "Smith");
@@ -316,7 +321,8 @@ mod tests {
         let record = create_test_record(&["keyword1; keyword2; keyword3"]);
         let config = CsvConfig::new();
 
-        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0).unwrap();
+        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv)
+            .unwrap();
 
         assert_eq!(raw.keywords.len(), 3);
         assert!(raw.keywords.contains(&"keyword1".to_string()));
@@ -328,7 +334,8 @@ mod tests {
         let record = create_test_record(&["Test Article", "Extra Field"]);
         let config = CsvConfig::new(); // flexible = false by default
 
-        let result = RawCsvData::from_record(&headers, &record, &config, 1, 0);
+        let result =
+            RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv);
         assert!(result.is_err());
     }
 
@@ -339,7 +346,8 @@ mod tests {
         let mut config = CsvConfig::new();
         config.set_flexible(true);
 
-        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0).unwrap();
+        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv)
+            .unwrap();
         assert_eq!(raw.get_field("title"), Some(&"Test Article".to_string()));
     }
 
@@ -353,7 +361,8 @@ mod tests {
         let record = create_test_record(&["Test Article", "Smith, John", "2023"]);
         let config = CsvConfig::new();
 
-        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0).unwrap();
+        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv)
+            .unwrap();
         let citation: crate::Citation = raw.try_into().unwrap();
 
         assert_eq!(citation.title, "Test Article");
@@ -367,7 +376,8 @@ mod tests {
         let record = create_test_record(&["Smith, John"]);
         let config = CsvConfig::new();
 
-        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0).unwrap();
+        let raw = RawCsvData::from_record(&headers, &record, &config, 1, 0, &CitationFormat::Csv)
+            .unwrap();
         let result: Result<crate::Citation, _> = raw.try_into();
 
         // The error is now converted through the legacy bridge

--- a/src/endnote_xml/mod.rs
+++ b/src/endnote_xml/mod.rs
@@ -148,6 +148,7 @@ mod integration_tests {
       <language>English</language>
       <publisher>Elsevier</publisher>
       <isbn>1877-7503</isbn>
+      <accession-num>ENDNOTE-123</accession-num>
       <custom2>PMC9876543</custom2>
     </record>
     <record>
@@ -206,6 +207,7 @@ mod integration_tests {
         assert_eq!(citation1.language, Some("English".to_string()));
         assert_eq!(citation1.publisher, Some("Elsevier".to_string()));
         assert_eq!(citation1.issn, vec!["1877-7503".to_string()]); // From ISBN field
+        assert_eq!(citation1.accession_number, Some("ENDNOTE-123".to_string()));
         assert_eq!(citation1.pmc_id, Some("PMC9876543".to_string()));
 
         // Test second citation
@@ -243,6 +245,25 @@ mod integration_tests {
         let citations = parse_endnote_xml(xml).unwrap();
         assert_eq!(citations.len(), 1);
         assert_eq!(citations[0].title, "Minimal Citation");
+    }
+
+    #[test]
+    fn test_accession_num_is_parsed() {
+        let xml = r#"
+        <xml>
+          <records>
+            <record>
+              <titles>
+                <title>Minimal Citation</title>
+              </titles>
+              <accession-num>ACC-789</accession-num>
+            </record>
+          </records>
+        </xml>
+        "#;
+
+        let citations = parse_endnote_xml(xml).unwrap();
+        assert_eq!(citations[0].accession_number.as_deref(), Some("ACC-789"));
     }
 
     #[test]

--- a/src/endnote_xml/parse.rs
+++ b/src/endnote_xml/parse.rs
@@ -285,6 +285,16 @@ fn parse_record<B: BufRead>(
                         citation.pmc_id = Some(text);
                     }
                 }
+                b"accession-num" => {
+                    let pos = reader.buffer_position() as usize;
+                    citation.accession_number = Some(extract_text_with_position(
+                        reader,
+                        buf,
+                        b"accession-num",
+                        content,
+                        pos,
+                    )?);
+                }
                 b"volume" => {
                     let pos = reader.buffer_position() as usize;
                     citation.volume = Some(extract_text_with_position(

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,7 @@ impl SourceSpan {
 pub mod fields {
     pub const TITLE: &str = "title";
     pub const AUTHOR: &str = "author";
+    pub const ACCESSION_NUMBER: &str = "accession_number";
     pub const DATE: &str = "date";
     pub const JOURNAL: &str = "journal";
     pub const JOURNAL_ABBR: &str = "journal_abbr";
@@ -278,6 +279,7 @@ mod tests {
         assert_eq!(format!("{}", CitationFormat::PubMed), "PubMed");
         assert_eq!(format!("{}", CitationFormat::EndNoteXml), "EndNote XML");
         assert_eq!(format!("{}", CitationFormat::Csv), "CSV");
+        assert_eq!(format!("{}", CitationFormat::IctrpCsv), "ICTRP CSV");
     }
 
     #[cfg(feature = "csv")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,139 +2,147 @@
 #![allow(clippy::type_complexity)]
 //! A comprehensive library for parsing, managing, and deduplicating academic citations.
 //!
-//! `biblib` provides robust functionality for working with academic citations in various formats.
-//! It focuses on accurate parsing, format conversion, and intelligent deduplication of citations.
+//! `biblib` parses citation exports from multiple sources into one normalized
+//! [`Citation`] model, then optionally deduplicates the result set.
 //!
-//! # Features
+//! It is designed for ingestion pipelines, review tooling, registry imports,
+//! and any workflow that needs to reconcile heterogeneous citation files.
 //!
-//! The library has several optional features that can be enabled in your Cargo.toml:
+//! # What You Get
 //!
-//! - `csv` - Enable CSV format support (enabled by default)
-//! - `pubmed` - Enable PubMed/MEDLINE format support (enabled by default)  
-//! - `xml` - Enable EndNote XML support (enabled by default)
-//! - `ris` - Enable RIS format support (enabled by default)
-//! - `dedupe` - Enable citation deduplication (enabled by default)
+//! - Dedicated parsers for RIS, PubMed / MEDLINE, EndNote XML, generic CSV,
+//!   and ICTRP CSV exports
+//! - A shared [`Citation`] output type with normalized identifiers such as DOI,
+//!   PMID, PMCID, and `accession_number`
+//! - Preservation of source-specific leftovers through `extra_fields`
+//! - Optional duplicate detection via [`dedupe::Deduplicator`]
+//! - Optional human-friendly parse diagnostics with the `diagnostics` feature
 //!
-//! To use only specific features, disable default features and enable just what you need:
-//!
-//! ```toml
-//! [dependencies]
-//! biblib = { version = "0.3.0", default-features = false, features = ["csv", "ris"] }
-//! ```
-//!
-//! # Key Characteristics
-//!
-//! - **Multiple Format Support**: Parse citations from:
-//!   - RIS (Research Information Systems)
-//!   - PubMed/MEDLINE
-//!   - EndNote XML
-//!   - CSV with configurable mappings
-//!
-//! - **Rich Metadata Support**:
-//!   - Authors with affiliations
-//!   - Journal details (name, abbreviation, ISSN)
-//!   - DOIs and other identifiers
-//!   - Complete citation metadata
-//!
-//! # Basic Usage
+//! # Quick Start
 //!
 //! ```rust
 //! use biblib::{CitationParser, RisParser};
 //!
-//! // Parse RIS format
 //! let input = r#"TY  - JOUR
 //! TI  - Example Article
 //! AU  - Smith, John
+//! DO  - 10.1000/example
 //! ER  -"#;
 //!
-//! let parser = RisParser::new();
-//! let citations = parser.parse(input).unwrap();
-//! println!("Title: {}", citations[0].title);
-//! ```
-//! # Citation Formats
+//! let citations = RisParser::new().parse(input).unwrap();
 //!
-//! Each format has a dedicated parser with format-specific features:
-//!
-//! ```rust
-//! use biblib::{RisParser, PubMedParser, EndNoteXmlParser, csv::CsvParser};
-//!
-//! // RIS format
-//! let ris = RisParser::new();
-//!
-//! // PubMed format
-//! let pubmed = PubMedParser::new();
-//!
-//! // EndNote XML format
-//! let endnote = EndNoteXmlParser::new();
-//!
-//! // CSV format
-//! let csv = CsvParser::new();
+//! assert_eq!(citations.len(), 1);
+//! assert_eq!(citations[0].title, "Example Article");
+//! assert_eq!(citations[0].doi.as_deref(), Some("10.1000/example"));
 //! ```
 //!
-//! # Citation Deduplication
+//! # Supported Parsers
 //!
 //! ```rust
-//! use biblib::{Citation, CitationParser, RisParser};
+//! use biblib::{CitationParser, EndNoteXmlParser, IctrpCsvParser, PubMedParser, RisParser};
+//! use biblib::csv::CsvParser;
 //!
-//! let ris_input = r#"TY  - JOUR
-//! TI  - Example Citation 1
-//! AU  - Smith, John
-//! ER  -
+//! let _ris = RisParser::new();
+//! let _pubmed = PubMedParser::new();
+//! let _endnote = EndNoteXmlParser::new();
+//! let _csv = CsvParser::new();
+//! let _ictrp = IctrpCsvParser::new();
+//! ```
 //!
-//! TY  - JOUR
-//! TI  - Example Citation 2
-//! AU  - Smith, John
-//! ER  -"#;
+//! # Auto-Detection
 //!
-//! let parser = RisParser::new();
-//! let mut citations = parser.parse(ris_input).unwrap();
+//! [`detect_and_parse`] currently auto-detects RIS, PubMed, EndNote XML, and
+//! ICTRP CSV. Generic CSV remains explicit because header mapping is
+//! application-specific.
 //!
-//! // Configure deduplication
+//! ```rust
+//! use biblib::detect_and_parse;
+//!
+//! let input = "TY  - JOUR\nTI  - Example\nER  -";
+//! let (citations, format) = detect_and_parse(input).unwrap();
+//!
+//! assert_eq!(format.as_str(), "RIS");
+//! assert_eq!(citations[0].title, "Example");
+//! ```
+//!
+//! # Feature Flags
+//!
+//! Disable default features when you only need a subset of parsers:
+//!
+//! ```toml
+//! [dependencies]
+//! biblib = { version = "0.5", default-features = false, features = ["ris", "csv"] }
+//! ```
+//!
+//! Available public features:
+//!
+//! - `ris`
+//! - `pubmed`
+//! - `xml`
+//! - `csv`
+//! - `dedupe`
+//! - `diagnostics`
+//!
+//! Since `v0.5`, `biblib` no longer uses the `regex` crate or exposes regex
+//! backend feature flags. It uses `regex-lite` internally, and regex backend
+//! choice is not part of the public feature surface.
+//!
+//! # Deduplication
+//!
+//! ```rust
 //! use biblib::dedupe::{Deduplicator, DeduplicatorConfig};
+//! use biblib::{Citation, Date};
 //!
-//! // Configure deduplication
+//! let citations = vec![
+//!     Citation {
+//!         title: "Example Title".to_string(),
+//!         doi: Some("10.1000/example".to_string()),
+//!         date: Some(Date { year: 2023, month: None, day: None }),
+//!         journal: Some("Example Journal".to_string()),
+//!         ..Default::default()
+//!     },
+//!     Citation {
+//!         title: "Example Title".to_string(),
+//!         doi: Some("10.1000/example".to_string()),
+//!         date: Some(Date { year: 2023, month: None, day: None }),
+//!         journal: Some("Example Journal".to_string()),
+//!         ..Default::default()
+//!     },
+//! ];
+//!
 //! let config = DeduplicatorConfig {
 //!     group_by_year: true,
 //!     run_in_parallel: true,
-//!     ..Default::default()
+//!     source_preferences: vec!["PubMed".to_string()],
 //! };
 //!
-//! let deduplicator = Deduplicator::new().with_config(config);
-//! let duplicate_groups = deduplicator.find_duplicates(&citations).unwrap();
+//! let groups = Deduplicator::new()
+//!     .with_config(config)
+//!     .find_duplicates(&citations)
+//!     .unwrap();
 //!
-//! for group in duplicate_groups {
-//!     println!("Original: {}", group.unique.title);
-//!     for duplicate in group.duplicates {
-//!         println!("  Duplicate: {}", duplicate.title);
-//!     }
-//! }
+//! let duplicate_group = groups
+//!     .iter()
+//!     .find(|group| group.unique.doi.as_deref() == Some("10.1000/example"))
+//!     .unwrap();
+//!
+//! assert_eq!(duplicate_group.duplicates.len(), 1);
 //! ```
 //!
-//! # Error Handling
+//! # Errors and Diagnostics
 //!
-//! The library uses a custom [`Result`] type that wraps [`CitationError`] for consistent
-//! error handling across all operations:
+//! Parsers return [`ParseError`] with line numbers and, when available, source
+//! spans.
 //!
 //! ```rust
-//! use biblib::{CitationParser, RisParser, CitationError};
+//! use biblib::{CitationParser, RisParser, ValueError};
 //!
-//! let result = RisParser::new().parse("invalid input");
-//! match result {
-//!     Ok(citations) => println!("Parsed {} citations", citations.len()),
-//!     Err(e) => eprintln!("Parse error: {}", e),
-//! }
+//! let input = "TY  - JOUR\nAU  - Smith, John\nER  -\n";
+//! let err = RisParser::new().parse(input).unwrap_err();
+//!
+//! assert_eq!(err.line, Some(1));
+//! assert!(matches!(err.error, ValueError::MissingValue { key: "TI", .. }));
 //! ```
-//!
-//! # Performance Considerations
-//!
-//! - Use year-based grouping for large datasets
-//! - Enable parallel processing for better performance
-//! - Consider using CSV format for very large datasets
-//!
-//! # Thread Safety
-//!
-//! All parser implementations are thread-safe and can be shared between threads.
-//! The deduplicator supports parallel processing through the `run_in_parallel` option.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -158,7 +166,7 @@ pub mod ris;
 
 // Reexports
 #[cfg(feature = "csv")]
-pub use csv::CsvParser;
+pub use csv::{CsvParser, IctrpCsvParser};
 #[cfg(feature = "diagnostics")]
 pub use diagnostics::parse_with_diagnostics;
 #[cfg(feature = "xml")]
@@ -179,6 +187,7 @@ pub enum CitationFormat {
     PubMed,
     EndNoteXml,
     Csv,
+    IctrpCsv,
     Unknown,
 }
 
@@ -190,6 +199,7 @@ impl CitationFormat {
             CitationFormat::PubMed => "PubMed",
             CitationFormat::EndNoteXml => "EndNote XML",
             CitationFormat::Csv => "CSV",
+            CitationFormat::IctrpCsv => "ICTRP CSV",
             CitationFormat::Unknown => "Unknown",
         }
     }
@@ -253,6 +263,8 @@ pub struct Citation {
     pub issn: Vec<String>,
     /// Digital Object Identifier
     pub doi: Option<String>,
+    /// Accession number or registry identifier
+    pub accession_number: Option<String>,
     /// PubMed ID
     pub pmid: Option<String>,
     /// PMC ID
@@ -381,6 +393,15 @@ pub fn detect_and_parse(
         return Err(CitationError::UnknownFormat);
     }
 
+    #[cfg(feature = "csv")]
+    if csv::looks_like_ictrp_csv(content) {
+        let parser = IctrpCsvParser::new();
+        return parser
+            .parse(content)
+            .map(|citations| (citations, CitationFormat::IctrpCsv))
+            .map_err(CitationError::Parse);
+    }
+
     Err(CitationError::UnknownFormat)
 }
 
@@ -452,5 +473,22 @@ FAU - Smith, John"#;
         let content = "Some random content\nthat doesn't match\nany known format";
         let result = detect_and_parse(content);
         assert!(matches!(result, Err(CitationError::UnknownFormat)));
+    }
+
+    #[cfg(feature = "csv")]
+    #[test]
+    fn test_detect_and_parse_ictrp_csv() {
+        let content = concat!(
+            "TrialID,Public title,Scientific title,Date registration,Date registration3,",
+            "Source Register\n",
+            "NCT00000001,Public,Scientific,01/05/2026,20260501,ClinicalTrials.gov\n"
+        );
+
+        let (citations, format) = detect_and_parse(content).unwrap();
+        assert_eq!(format, CitationFormat::IctrpCsv);
+        assert_eq!(
+            citations[0].accession_number.as_deref(),
+            Some("NCT00000001")
+        );
     }
 }

--- a/src/pubmed/structure.rs
+++ b/src/pubmed/structure.rs
@@ -84,6 +84,7 @@ impl TryFrom<RawPubmedData> for crate::Citation {
                         .filter_map(parse_doi_from_lid)
                         .next()
                 }),
+            accession_number: None,
             pmid: data
                 .remove(&PubmedTag::PubmedUniqueIdentifier)
                 .and_then(join_if_some),

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,14 +1,3 @@
-//! Re-exports from either `regex` or `regex_lite`, depending on features.
+//! Re-exports from the internal `regex_lite` backend.
 
-#[cfg(all(feature = "regex", feature = "lite"))]
-compile_error!(
-    "Cannot enable both \"regex\" and \"lite\" features simultaneously. Please enable only one of them."
-);
-
-#[cfg(all(feature = "regex", not(feature = "lite")))]
-pub(crate) use regex::{Captures, Regex};
-#[cfg(feature = "lite")]
 pub(crate) use regex_lite::{Captures, Regex};
-
-#[cfg(not(any(feature = "regex", feature = "lite")))]
-compile_error!("biblib requires the \"regex\" or \"lite\" feature to be enabled");

--- a/src/ris/mod.rs
+++ b/src/ris/mod.rs
@@ -183,6 +183,34 @@ ER  -"#;
         assert_eq!(result[0].doi, Some("10.1000/test".to_string()));
     }
 
+    #[test]
+    fn test_parse_accession_number_from_an() {
+        let input = r#"TY  - JOUR
+TI  - Test Article
+AN  - ACC-123
+ER  -"#;
+
+        let citation = RisParser::new().parse(input).unwrap().remove(0);
+        assert_eq!(citation.accession_number.as_deref(), Some("ACC-123"));
+    }
+
+    #[test]
+    fn test_id_remains_in_extra_fields_when_an_present() {
+        let input = r#"TY  - JOUR
+TI  - Test Article
+AN  - ACC-123
+ID  - REF-456
+ER  -"#;
+
+        let citation = RisParser::new().parse(input).unwrap().remove(0);
+        assert_eq!(citation.accession_number.as_deref(), Some("ACC-123"));
+        assert_eq!(citation.pmid, None);
+        assert_eq!(
+            citation.extra_fields.get("ID"),
+            Some(&vec!["REF-456".to_string()])
+        );
+    }
+
     // ── Phase 4: line-number accuracy tests ─────────────────────────────────
 
     /// Missing TI in the very first citation (TY on line 1) must report line 1.

--- a/src/ris/structure.rs
+++ b/src/ris/structure.rs
@@ -131,6 +131,7 @@ impl TryFrom<RawRisData> for crate::Citation {
         let date = Self::extract_date(&mut raw);
         let (volume, issue, pages) = Self::extract_publication_details(&mut raw);
         let (doi, urls) = Self::extract_doi_and_urls(&mut raw);
+        let accession_number = Self::extract_accession_number(&mut raw);
         let (pmid, pmc_id) = Self::extract_identifiers(&mut raw);
         let abstract_text = Self::extract_abstract(&mut raw);
         let keywords = raw.remove(&RisTag::Keywords).unwrap_or_default();
@@ -150,6 +151,7 @@ impl TryFrom<RawRisData> for crate::Citation {
             pages,
             issn,
             doi,
+            accession_number,
             pmid,
             pmc_id,
             abstract_text,
@@ -302,18 +304,20 @@ impl crate::Citation {
         (doi, urls)
     }
 
-    /// Extract PMID and PMC ID identifiers.
-    fn extract_identifiers(raw: &mut RawRisData) -> (Option<String>, Option<String>) {
-        let pmid = raw
-            .remove(&RisTag::ReferenceId)
-            .and_then(|v| v.into_iter().next());
+    /// Extract accession number from the RIS AN tag.
+    fn extract_accession_number(raw: &mut RawRisData) -> Option<String> {
+        raw.remove(&RisTag::AccessionNumber)
+            .and_then(|v| v.into_iter().next())
+    }
 
+    /// Extract normalized identifiers while preserving raw reference IDs.
+    fn extract_identifiers(raw: &mut RawRisData) -> (Option<String>, Option<String>) {
         let pmc_id = raw
             .remove(&RisTag::PmcId)
             .and_then(|v| v.into_iter().next())
             .filter(|s| s.contains("PMC"));
 
-        (pmid, pmc_id)
+        (None, pmc_id)
     }
 
     /// Extract abstract text from primary or alternative abstract fields.

--- a/src/ris/tags.rs
+++ b/src/ris/tags.rs
@@ -54,6 +54,8 @@ pub enum RisTag {
     EndPage,
     /// DO - DOI
     Doi,
+    /// AN - Accession number
+    AccessionNumber,
     /// ID - Reference ID
     ReferenceId,
     /// AB - Abstract
@@ -115,6 +117,7 @@ impl RisTag {
             "SP" => RisTag::StartPage,
             "EP" => RisTag::EndPage,
             "DO" => RisTag::Doi,
+            "AN" => RisTag::AccessionNumber,
             "ID" => RisTag::ReferenceId,
             "AB" => RisTag::Abstract,
             "N2" => RisTag::AbstractAlternative,
@@ -159,6 +162,7 @@ impl RisTag {
             RisTag::StartPage => "SP",
             RisTag::EndPage => "EP",
             RisTag::Doi => "DO",
+            RisTag::AccessionNumber => "AN",
             RisTag::ReferenceId => "ID",
             RisTag::Abstract => "AB",
             RisTag::AbstractAlternative => "N2",
@@ -232,6 +236,7 @@ mod tests {
     #[case("TI", RisTag::Title)]
     #[case("AU", RisTag::Author)]
     #[case("JF", RisTag::JournalFull)]
+    #[case("AN", RisTag::AccessionNumber)]
     #[case("ER", RisTag::EndOfReference)]
     #[case("UNKNOWN", RisTag::Unknown("UNKNOWN".to_string()))]
     fn test_from_tag(#[case] input: &str, #[case] expected: RisTag) {


### PR DESCRIPTION
## Summary
- add `Citation.accession_number` and map it from ICTRP `TrialID`, RIS `AN`, and EndNote XML `<accession-num>`
- add dedicated `IctrpCsvParser` plus narrow ICTRP auto-detection in `detect_and_parse()`
- simplify regex handling by removing public regex backend feature flags and using `regex-lite` internally
- rewrite README and refresh crate-level docs to match the current API and feature surface
- prepare the crate for `0.5.0` with changelog and version updates

## Breaking changes
- `Citation` has a new public field: `accession_number: Option<String>`
- `CitationFormat` has a new variant: `IctrpCsv`
- public `regex` / `lite` feature flags are removed in favor of internal `regex-lite`

## Notes
- RIS accession numbers now come from `AN`; `ID` remains preserved in `extra_fields`
- ICTRP citations always start `citation_type` with `Clinical Trial`, then append `Study type` when present
- docs and examples were updated and verified with doctests