### PR TITLE
Bump quick-xml to 0.41 and update XML parser paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ diagnostics = ["dep:ariadne"]
 [dependencies]
 thiserror = "2.0.18"
 ariadne = { version = "0.6.0", optional = true }
-quick-xml = { version = "0.39.2", optional = true }
+quick-xml = { version = "0.41", optional = true }
 csv = { version = "1.4.0", optional = true }
 strsim = { version = "0.11.1", optional = true }
 rayon = { version = "1.11.0", optional = true }

--- a/src/endnote_xml/parse.rs
+++ b/src/endnote_xml/parse.rs
@@ -5,6 +5,7 @@
 use crate::error::{ParseError, SourceSpan, ValueError};
 use crate::{Author, Citation, CitationFormat};
 use quick_xml::Reader;
+use quick_xml::XmlVersion;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use std::io::BufRead;
@@ -32,7 +33,7 @@ fn extract_text_with_position<B: BufRead>(
         let current_pos = reader.buffer_position() as usize;
         match reader.read_event_into(buf) {
             Ok(Event::Text(e)) => {
-                text.push_str(&e.xml_content().map_err(|e| {
+                text.push_str(&e.xml_content(XmlVersion::Explicit1_1).map_err(|e| {
                     let line_num = buffer_position_to_line_number(content, current_pos);
                     ParseError::at_line(
                         line_num,
@@ -215,7 +216,10 @@ fn parse_record<B: BufRead>(
                         })?;
                         if attr.key.as_ref() == b"name" {
                             citation.citation_type.push(
-                                attr.unescape_value()
+                                attr.decoded_and_normalized_value(
+                                    XmlVersion::Explicit1_1,
+                                    reader.decoder(),
+                                )
                                     .map_err(|e| {
                                         ParseError::at_line(
                                             attr_line,


### PR DESCRIPTION
## Summary

Bumps `quick-xml` from 0.39.2 to 0.41 and updates the EndNote XML parser to
the new API so the XML paths build and test green again. Closes #26.

`quick-xml` is only used by the XML parsers, and this change is limited to the
dependency bump plus the internal parser calls it forces. No public API changes.

## Changes

- `Cargo.toml`: `quick-xml` `0.39.2` → `0.41`.
- `src/endnote_xml/parse.rs`, two call-site updates required by 0.41:
  - `Event::xml_content()` now takes an explicit `XmlVersion`
    (`xml_content(XmlVersion::Explicit1_1)`).
  - `Attribute::unescape_value()` is deprecated in 0.41 and is compiled out
    when the `encoding` feature is enabled. Switched to
    `decoded_and_normalized_value(XmlVersion::Explicit1_1, reader.decoder())`,
    which is the API quick-xml recommends for libraries so the crate keeps
    compiling if a downstream project enables `encoding` (feature unification).

`src/ictrp/xml.rs` needed no changes: it uses `Event::decode()` and the
`quick_xml::escape::unescape` free function, both unchanged in 0.41.

## Compatibility

Both edited functions are private, so biblib's public API is unchanged.

Note: I used `XmlVersion::Explicit1_1` for the version argument. If you'd
prefer to preserve the pre-0.41 XML 1.0 normalization behavior exactly, these
can be `XmlVersion::Implicit1_0` instead. Happy to switch if you'd rather keep
1.0 semantics.

## Testing

- `cargo build` (default features, includes `xml`): clean.
- `cargo test`: 295 unit tests + 31 doc tests pass, 0 failed.
- `cargo clippy`: no warnings.